### PR TITLE
Let the user decide if he wants to proceed with one repo

### DIFF
--- a/monorepo_build.sh
+++ b/monorepo_build.sh
@@ -11,7 +11,7 @@
 
 # Check provided arguments
 if [ "$#" -lt "2" ]; then
-    echo 'You have provided at least 2 remotes to be merged into a new monorepo'
+    echo 'Please provide at least 2 remotes to be merged into a new monorepo'
     echo 'Usage: monorepo_build.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...'
     echo 'Example: monorepo_build.sh main-repository package-alpha:packages/alpha package-beta:packages/beta'
     read -p "Do you want to proceed? (y/n) " yn

--- a/monorepo_build.sh
+++ b/monorepo_build.sh
@@ -11,10 +11,17 @@
 
 # Check provided arguments
 if [ "$#" -lt "2" ]; then
-    echo 'Please provide at least 2 remotes to be merged into a new monorepo'
+    echo 'You have provided at least 2 remotes to be merged into a new monorepo'
     echo 'Usage: monorepo_build.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...'
     echo 'Example: monorepo_build.sh main-repository package-alpha:packages/alpha package-beta:packages/beta'
-    exit
+    read -p "Do you want to proceed? (y/n) " yn
+    case $yn in 
+    	[yY] ) echo Proceeding;
+    		break;;
+    	[nN] ) echo exiting...;
+    		exit;;
+    	* ) echo invalid response;;
+    esac
 fi
 # Get directory of the other scripts
 MONOREPO_SCRIPT_DIR=$(dirname "$0")

--- a/monorepo_build.sh
+++ b/monorepo_build.sh
@@ -18,9 +18,8 @@ if [ "$#" -lt "2" ]; then
     case $yn in 
     	[yY] ) echo Proceeding;
     		break;;
-    	[nN] ) echo exiting...;
+    	* ) echo exiting...;
     		exit;;
-    	* ) echo invalid response;;
     esac
 fi
 # Get directory of the other scripts


### PR DESCRIPTION
We're using the [monorepo-tools](https://github.com/shopsys/monorepo-tools) quite frequently and it makes sense, in our context, to build a monorepo with only one repo and add other repos later.
We are currently commenting out the `exit` to use the tools to fit our needs, but better practice would be to let the user decide if he wants to use only 1 repo.