### PR TITLE
Update branch references from 'master' to 'main'

### DIFF
--- a/load_branches_from_remote.sh
+++ b/load_branches_from_remote.sh
@@ -20,5 +20,5 @@ for REMOTE_BRANCH in $(git branch -r|grep $REMOTE/); do
     git branch -q $BRANCH $REMOTE_BRANCH
     git branch --unset-upstream $BRANCH
 done
-git checkout -f master
+git checkout -f main
 

--- a/monorepo_add.sh
+++ b/monorepo_add.sh
@@ -2,7 +2,7 @@
 
 # Add repositories to a monorepo from specified remotes
 # You must first add the remotes by "git remote add <remote-name> <repository-url>" and fetch from them by "git fetch --all"
-# It will merge master branches of the monorepo and all remotes together while keeping all current branches in monorepo intact
+# It will merge main branches of the monorepo and all remotes together while keeping all current branches in monorepo intact
 # If subdirectory is not specified remote name will be used instead
 #
 # Usage: monorepo_add.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...
@@ -28,21 +28,21 @@ for PARAM in $@; do
     if [ "$SUBDIRECTORY" == "" ]; then
         SUBDIRECTORY=$REMOTE
     fi
-    echo "Building branch 'master' of the remote '$REMOTE'"
-    git checkout --detach $REMOTE/master
+    echo "Building branch 'main' of the remote '$REMOTE'"
+    git checkout --detach $REMOTE/main
     $MONOREPO_SCRIPT_DIR/rewrite_history_into.sh $SUBDIRECTORY
     MERGE_REFS="$MERGE_REFS $(git rev-parse HEAD)"
     # Wipe the back-up of original history
     $MONOREPO_SCRIPT_DIR/original_refs_wipe.sh
 done
-# Merge all master branches
+# Merge all main branches
 COMMIT_MSG="merge multiple repositories into an existing monorepo"$'\n'$'\n'"- merged using: 'monorepo_add.sh $@'"$'\n'"- see https://github.com/shopsys/monorepo-tools"
-git checkout master
+git checkout main
 echo "Merging refs: $MERGE_REFS"
 git merge --no-commit -q $MERGE_REFS --allow-unrelated-histories
 echo 'Resolving conflicts using trees of all parents'
 for REF in $MERGE_REFS; do
-    # Add all files from all master branches into index
+    # Add all files from all main branches into index
     # "git read-tree" with multiple refs cannot be used as it is limited to 8 refs
     git ls-tree -r $REF | git update-index --index-info
 done

--- a/monorepo_build.sh
+++ b/monorepo_build.sh
@@ -2,7 +2,7 @@
 
 # Build monorepo from specified remotes
 # You must first add the remotes by "git remote add <remote-name> <repository-url>" and fetch from them by "git fetch --all"
-# Final monorepo will contain all branches from the first remote and master branches of all remotes will be merged
+# Final monorepo will contain all branches from the first remote and main branches of all remotes will be merged
 # If subdirectory is not specified remote name will be used instead
 #
 # Usage: monorepo_build.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...
@@ -34,29 +34,29 @@ for PARAM in $@; do
     if [ "$SUBDIRECTORY" == "" ]; then
         SUBDIRECTORY=$REMOTE
     fi
-    # Rewrite all branches from the first remote, only master branches from others
+    # Rewrite all branches from the first remote, only main branches from others
     if [ "$PARAM" == "$1" ]; then
         echo "Building all branches of the remote '$REMOTE'"
         $MONOREPO_SCRIPT_DIR/load_branches_from_remote.sh $REMOTE
         $MONOREPO_SCRIPT_DIR/rewrite_history_into.sh $SUBDIRECTORY --branches
-        MERGE_REFS='master'
+        MERGE_REFS='main'
     else
-        echo "Building branch 'master' of the remote '$REMOTE'"
-        git checkout --detach $REMOTE/master
+        echo "Building branch 'main' of the remote '$REMOTE'"
+        git checkout --detach $REMOTE/main
         $MONOREPO_SCRIPT_DIR/rewrite_history_into.sh $SUBDIRECTORY
         MERGE_REFS="$MERGE_REFS $(git rev-parse HEAD)"
     fi
     # Wipe the back-up of original history
     $MONOREPO_SCRIPT_DIR/original_refs_wipe.sh
 done
-# Merge all master branches
+# Merge all main branches
 COMMIT_MSG="merge multiple repositories into a monorepo"$'\n'$'\n'"- merged using: 'monorepo_build.sh $@'"$'\n'"- see https://github.com/shopsys/monorepo-tools"
-git checkout master
+git checkout main
 echo "Merging refs: $MERGE_REFS"
 git merge --no-commit -q $MERGE_REFS --allow-unrelated-histories
 echo 'Resolving conflicts using trees of all parents'
 for REF in $MERGE_REFS; do
-    # Add all files from all master branches into index
+    # Add all files from all main branches into index
     # "git read-tree" with multiple refs cannot be used as it is limited to 8 refs
     git ls-tree -r $REF | git update-index --index-info
 done

--- a/monorepo_split.sh
+++ b/monorepo_split.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Split monorepo and push all master branches and all tags into specified remotes
+# Split monorepo and push all main branches and all tags into specified remotes
 # You must first build the monorepo via "monorepo_build" (uses same parameters as "monorepo_split")
 # If subdirectory is not specified remote name will be used instead
 #
@@ -27,13 +27,13 @@ for PARAM in $@; do
     if [ "$SUBDIRECTORY" == "" ]; then
         SUBDIRECTORY=$REMOTE
     fi
-    # Rewrite git history of master branch
+    # Rewrite git history of main branch
     echo "Splitting repository for the remote '$REMOTE'"
-    git checkout master
-    $MONOREPO_SCRIPT_DIR/rewrite_history_from.sh $SUBDIRECTORY master $(git tag)
+    git checkout main
+    $MONOREPO_SCRIPT_DIR/rewrite_history_from.sh $SUBDIRECTORY main $(git tag)
     if [ $? -eq 0 ]; then
-        echo "Pushing branch 'master' and all tags into '$REMOTE'"
-        git push --tags $REMOTE master
+        echo "Pushing branch 'main' and all tags into '$REMOTE'"
+        git push --tags $REMOTE main
     else
         echo "Splitting repository for the remote '$REMOTE' failed! Not pushing anything into it."
     fi


### PR DESCRIPTION
Github (and other tools) have been using `main` branch for a while now so it makes sense to update monorepo tools with that.